### PR TITLE
add missing include for ShaderBlob.h

### DIFF
--- a/include/ShaderMake/ShaderBlob.h
+++ b/include/ShaderMake/ShaderBlob.h
@@ -24,6 +24,7 @@
 
 #include <vector>
 #include <string>
+#include <cstdint>
 
 namespace ShaderMake
 {


### PR DESCRIPTION
add a missing include for this file. found I was unable to compile this using the gnu compiler. 

```
[ 52%] Building CXX object ShaderMake/CMakeFiles/ShaderMakeBlob.dir/src/ShaderBlob.cpp.o
In file included from /home/michaelpollind/projects/donut/ShaderMake/src/ShaderBlob.cpp:23:
/home/michaelpollind/projects/donut/ShaderMake/include/ShaderMake/ShaderBlob.h:39:5: error: ‘uint32_t’ does not name a type
   39 |     uint32_t permutationSize;
      |     ^~~~~~~~
/home/michaelpollind/projects/donut/ShaderMake/include/ShaderMake/ShaderBlob.h:27:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   26 | #include <string>
  +++ |+#include <cstdint>
   27 | 
/home/michaelpollind/projects/donut/ShaderMake/include/ShaderMake/ShaderBlob.h:40:5: error: ‘uint32_t’ does not name a type
   40 |     uint32_t dataSize;
      |     ^~~~~~~~
/home/michaelpollind/projects/donut/ShaderMake/include/ShaderMake/ShaderBlob.h:40:5: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/michaelpollind/projects/donut/ShaderMake/include/ShaderMake/ShaderBlob.h:47:5: error: ‘uint32_t’ has not been declared

```