### PR TITLE
Catch rare exceptions from fs::remove instead of crashing.

### DIFF
--- a/ShaderMake/ShaderMake.cpp
+++ b/ShaderMake/ShaderMake.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2023, NVIDIA CORPORATION. All rights reserved.
+Copyright (c) 2014-2025, NVIDIA CORPORATION. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -1183,9 +1183,20 @@ void ExeCompile()
                     context.WriteDataAsText(buffer.data(), buffer.size());
                     context.WriteTextEpilog();
 
-                    // Delete the binary file if it's not requested
+                    // Try to delete the binary file if it's not requested.
+					// In the unlikely event it fails (one system sometimes holds the file handle too long),
+					// avoid a fatal exit because it's merely an intermediate file.
                     if (!g_Options.binary)
-                        fs::remove(outputFile);
+					{
+						try
+						{
+							fs::remove(outputFile);
+						}
+						catch(const std::exception& e)
+						{
+							Printf(YELLOW "Could not delete temporary binary file '%s': %s\n", outputFile.c_str(), e.what());
+						}
+					}
                 }
                 else
                 {


### PR DESCRIPTION
On one of our CI machines, NRD's build would sometimes fail at random points while generating embedded shader headers using ShaderMake. This would result in a cryptic error message like this:

```
Compiling shaders using: C:/VulkanSDK/1.4.313.2/Bin/dxc.exe
  ( 10%) NRD SPIRV
  The system cannot find the batch label specified - VCEnd
```

The `VCEnd` message is a CMake bug: see https://gitlab.kitware.com/cmake/cmake/-/issues/26678 .

It turned out that on that machine, a handle to the output file would sometimes still be held by a `cmd` subprocess. This should never happen since ShaderMake calls `_pclose`, which waits for the subprocess to terminate, but it seems that on this specific system it sometimes does. Here's a screenshot captured from Process Explorer with ShaderMake in a debugger at the moment the `fs::remove` call throws, showing a suspended `cmd` subprocess holding onto the output file.

<img width="774" height="504" alt="image" src="https://github.com/user-attachments/assets/56d6a994-20d7-4e40-837f-622f7edef495" />

This patch catches the exception if it occurs and instead prints a warning message that looks like this:

```
  Compiling shaders using: C:/VulkanSDK/1.4.313.2/Bin/dxc.exe
  ( 10%) NRD SPIRV
  Could not delete temporary binary file: 'remov
  e: The process cannot access the file because it is being used by another process.: "C:\Users\nbickford\Documents\NRD
  \_Shaders\SIGMA_SmoothTiles.cs.spirv"'
  ( 20%) NRD SPIRV
  ( 30%) NRD SPIRV
  ( 40%) NRD SPIRV
  ( 50%) NRD SPIRV
  ( 60%) NRD SPIRV
  ( 70%) NRD SPIRV
  ( 80%) NRD SPIRV
  ( 90%) NRD SPIRV
  (100%) NRD SPIRV
  159 task(s) completed successfully (elapsed time 5663.02 ms)
```

If this happens, the temporary file will be left over after ShaderMake finishes; that should be better than crashing.

Thanks!